### PR TITLE
Extend API for compatibility with TinyDB v3.6+

### DIFF
--- a/tinyrecord/operations.py
+++ b/tinyrecord/operations.py
@@ -29,10 +29,10 @@ class InsertMultiple(Operation):
         self.iterable = iterable
 
     def perform(self, data):
-        eid = max(data) if data else 0
+        doc_id = max(data) if data else 0
         for element in self.iterable:
-            eid += 1
-            data[eid] = element
+            doc_id += 1
+            data[doc_id] = element
 
 
 class UpdateCallable(Operation):
@@ -43,15 +43,18 @@ class UpdateCallable(Operation):
 
     :param fields: The fields to update.
     """
-    def __init__(self, function, query=null_query, eids=[]):
+    def __init__(self, function, query=null_query, doc_ids=[], eids=[]):
         self.function = function
         self.query = query
+        if eids and doc_ids:
+            raise TypeError('cannot pass both eids and doc_ids')
+        self.doc_ids = set(doc_ids)
         self.eids = set(eids)
 
     def perform(self, data):
         for key in data:
             value = data[key]
-            if key in self.eids or self.query(value):
+            if key in self.doc_ids or self.eids or self.query(value):
                 self.function(value)
 
 
@@ -62,11 +65,14 @@ class Remove(Operation):
 
     :param query: The query to remove.
     """
-    def __init__(self, query=null_query, eids=[]):
+    def __init__(self, query=null_query, doc_ids=[], eids=[]):
         self.query = query
+        if eids and doc_ids:
+            raise TypeError('cannot pass both eids and doc_ids')
+        self.doc_ids = set(doc_ids)
         self.eids = set(eids)
 
     def perform(self, data):
         for key in list(data):
-            if key in self.eids or self.query(data[key]):
+            if key in self.doc_ids or self.eids or self.query(data[key]):
                 del data[key]

--- a/tinyrecord/transaction.py
+++ b/tinyrecord/transaction.py
@@ -63,9 +63,11 @@ class transaction(object):
     def insert(self, row):
         return self.insert_multiple((row,))
 
-    def update(self, fields, query=null_query, eids=[]):
+    def update(self, fields, query=null_query, doc_ids=[], eids=[]):
         updator = lambda doc: doc.update(fields)
-        return self.update_callable(updator, query, eids)
+        if eids and doc_ids:
+            raise TypeError('cannot pass both eids and doc_ids')
+        return self.update_callable(updator, query, doc_ids, eids)
 
     def __enter__(self):
         """


### PR DESCRIPTION
TinyDB v3.6.0 renamed the `Element` class `Document`, and renamed the `eid` property `doc_id`.

This code allows people to use the new `doc_ids` syntax with the transaction class methods as well as the legacy `eids` syntax.