### PR TITLE
Fix bug where using eids would apply actions to all records

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -47,40 +47,48 @@ def test_remove(db):
 
 def test_remove_eids(db):
     eid = db.insert({'x': 1})
+    other_eid = db.insert({'x': 4})
 
     with transaction(db) as tr:
         tr.remove(eids=[eid])
 
     assert not db.get(eid=eid)
+    assert db.get(eid=other_eid)
 
 
 def test_remove_doc_ids(db):
     doc_id = db.insert({'x': 1})
+    other_doc_id = db.insert({'x': 4})
 
     with transaction(db) as tr:
         tr.remove(doc_ids=[doc_id])
 
     assert not db.get(doc_id=doc_id)
+    assert db.get(doc_id=other_doc_id)
 
 
 def test_legacy_update(db):
     eid = db.insert({'x': 1})
+    other_eid = db.insert({'x': 4})
 
     with transaction(db) as tr:
         tr.update({'x': 2}, where('x') == 1)
         tr.update({'x': 3}, eids=[eid])
 
     assert db.get(where('x') == 3).eid == eid
+    assert db.get(where('x') == 4).eid == other_eid
 
 
 def test_update(db):
     doc_id = db.insert({'x': 1})
+    other_doc_id = db.insert({'x': 4})
 
     with transaction(db) as tr:
         tr.update({'x': 2}, where('x') == 1)
         tr.update({'x': 3}, doc_ids=[doc_id])
 
     assert db.get(where('x') == 3).doc_id == doc_id
+    assert db.get(where('x') == 4).doc_id == other_doc_id
 
 
 def test_atomicity(db):

--- a/tinyrecord/operations.py
+++ b/tinyrecord/operations.py
@@ -54,7 +54,7 @@ class UpdateCallable(Operation):
     def perform(self, data):
         for key in data:
             value = data[key]
-            if key in self.doc_ids or self.eids or self.query(value):
+            if key in self.doc_ids or key in self.eids or self.query(value):
                 self.function(value)
 
 
@@ -74,5 +74,5 @@ class Remove(Operation):
 
     def perform(self, data):
         for key in list(data):
-            if key in self.doc_ids or self.eids or self.query(data[key]):
+            if key in self.doc_ids or key in self.eids or self.query(data[key]):
                 del data[key]


### PR DESCRIPTION
Bug introduced in 011f91 where test for records to apply an action to
would always return true if any eids were given.