### PR TITLE
Add type annotations and run mypy on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9"
     - "pypy3"
-install: pip install tinydb
-script: pytest tests.py
+install: pip install tox
+script: tox -e mypy,py

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,11 @@ Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 License :: OSI Approved :: MIT License
 Programming Language :: Python
-Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3 :: Only
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows
@@ -22,7 +23,9 @@ setup(
     name='tinyrecord',
     version='0.2.0',
     packages=['tinyrecord'],
-    python_requires='>=3.5',
+    package_data={'tinyrecord': ['py.typed']},
+    python_requires='>=3.6',
+    install_requires=['tinydb >= 4.0.0'],
     classifiers=filter(None, classifiers.split('\n')),
     zip_safe=True,
     author='Eugene Eeo',

--- a/tinyrecord/changeset.py
+++ b/tinyrecord/changeset.py
@@ -1,3 +1,10 @@
+from typing import Any, Dict, List
+
+from tinydb.table import Table
+
+from tinyrecord.operations import Operation
+
+
 class Changeset:
     """
     A changeset represents a series of changes that
@@ -6,11 +13,11 @@ class Changeset:
     :param table: The TinyDB table.
     """
 
-    def __init__(self, table):
+    def __init__(self, table: Table) -> None:
         self.table = table
-        self.record = []
+        self.record: List[Operation] = []
 
-    def execute(self):
+    def execute(self) -> None:
         """
         Execute the changeset, applying every
         operation on the database. Note that this
@@ -18,14 +25,14 @@ class Changeset:
         it again and again it will be executed
         many times.
         """
-        def updater(docs):
+        def updater(docs: Dict[int, Any]) -> None:
             for op in self.record:
                 op.perform(docs)
 
         self.table._update_table(updater)
         self.table._next_id = None
 
-    def append(self, change):
+    def append(self, change: Operation) -> None:
         """
         Append a *change* to the internal record
         of operations.

--- a/tinyrecord/transaction.py
+++ b/tinyrecord/transaction.py
@@ -1,6 +1,11 @@
 from functools import wraps
 from threading import Lock
+from types import TracebackType
+from typing import Any, Callable, MutableMapping, NoReturn, Optional, Type
 from weakref import WeakKeyDictionary
+
+from tinydb.table import Table
+
 from tinyrecord.changeset import Changeset
 from tinyrecord.operations import (Remove,
                                    InsertMultiple,
@@ -16,7 +21,7 @@ class AbortSignal(Exception):
     pass
 
 
-def abort():
+def abort() -> NoReturn:
     """
     Aborts the transaction. All operations defined on
     the transaction will be ignored (discarded).
@@ -26,7 +31,7 @@ def abort():
     raise AbortSignal
 
 
-def records(cls):
+def records(cls: Type[Operation]) -> Callable[..., None]:
     """
     Helper method for creating a method that records
     another operation to the changeset.
@@ -34,8 +39,9 @@ def records(cls):
     :param cls: The operation class.
     """
     @wraps(cls)
-    def proxy(self, *args, **kwargs):
-        self.record.append(cls(*args, **kwargs))
+    def proxy(self: "transaction", *args: Any, **kwargs: Any) -> None:
+        # Too many arguments for "Operation"
+        self.record.append(cls(*args, **kwargs))  # type: ignore[call-arg]
     return proxy
 
 
@@ -48,9 +54,9 @@ class transaction:
     :param table: A TinyDB table.
     """
 
-    _locks = WeakKeyDictionary()
+    _locks: MutableMapping[Table, Lock] = WeakKeyDictionary()
 
-    def __init__(self, table):
+    def __init__(self, table: Table) -> None:
         self.record = Changeset(table)
         self.lock = (self._locks.get(table) or
                      self._locks.setdefault(table, Lock()))
@@ -59,16 +65,21 @@ class transaction:
     update = records(Update)
     remove = records(Remove)
 
-    def insert(self, row):
-        return self.insert_multiple((row,))
+    def insert(self, row: Any) -> None:
+        self.insert_multiple((row,))
 
-    def __enter__(self):
+    def __enter__(self) -> "transaction":
         """
         Enter a transaction.
         """
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(
+        self,
+        type: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType]
+    ) -> bool:
         """
         Commits the transaction and raises a traceback
         if it is not an ``AbortSignal``. All actions

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py{36,37,38,39,py3}, mypy
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest tests.py
+
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    mypy --pretty --show-error-codes --strict tinyrecord


### PR DESCRIPTION
Type annotations help library users by providing type contracts for
public APIs. Library users can use tools such as mypy to build
confidence that they are using tinyrecord correctly. It also helps
internally by checking the library's own usage for consistency and
correctness.

tinyrecord now distributes a py.typed file for PEP-561 compliance:
https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

The TinyDB project also distributes type annotations, so this is aligned
with upstream.

Other changes:

- Added a tox.ini file for an easy entry point to run mypy and tests.

- Dropped support for Python 3.5 which doesn't support all modern type
  annotation syntax. Python 3.5 is end-of-line anyway (since 2020-09-30).

- Added CI testing fro Python 3.9.

- Added TinyDB as an explicit dependency as type annotations contain
  references to it.