### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U wheel
+          python -m pip install -U tox
+
+      - name: Tox tests
+        run: |
+          tox -e py
+
+      - name: Tox MyPy
+        if: "!startsWith(matrix.python-version, 'pypy')"
+        run: |
+          tox -e mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,30 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["pypy3.8", "3.6", "3.7", "3.8", "3.9"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+          cache: pip
+          cache-dependency-path: setup.py
 
       - name: Install dependencies
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-    - "3.9"
-    - "pypy3"
-install: pip install tox
-script: tox -e mypy,py

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,6 @@ only support the latest version (**4.x**).
 
 Installation is as simple as ``pip install tinyrecord``.
 
-.. image:: https://travis-ci.org/eugene-eeo/tinyrecord.svg?branch=master
-    :target: https://travis-ci.org/eugene-eeo/tinyrecord
+.. image:: https://github.com/eugene-eeo/tinyrecord/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/eugene-eeo/tinyrecord/actions/workflows/test.yml
 .. _TinyDB: https://github.com/msiemens/tinydb

--- a/tinyrecord/transaction.py
+++ b/tinyrecord/transaction.py
@@ -42,7 +42,7 @@ def records(cls: Type[Operation]) -> Callable[..., None]:
     @wraps(cls)
     def proxy(self: "transaction", *args: Any, **kwargs: Any) -> None:
         # Too many arguments for "Operation"
-        self.record.append(cls(*args, **kwargs))  # type: ignore[call-arg]
+        self.record.append(cls(*args, **kwargs))
     return proxy
 
 


### PR DESCRIPTION
Travis CI has a new pricing model which makes testing harder for open source projects.

And the last build at https://travis-ci.org/github/eugene-eeo/tinyrecord was 4 months ago:

> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.

Many projects are moving to GitHub Actions, which allows us to test on macOS and Windows in addition to Ubuntu, and we also get 20 parallel jobs instead of 5.

This PR tests on all 3 operating systems.

We also need to skip MyPy for PyPy, but can still run it on CPython:

* https://mypy.readthedocs.io/en/latest/faq.html#does-it-run-on-pypy

Sample builds:

* https://github.com/hugovk/tinyrecord/actions/runs/1329084774
* https://github.com/hugovk/tinyrecord/actions/runs/3133187606
