### PR TITLE
Add support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy3.8", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U wheel
+          python -m pip install -U tox
+
+      - name: Tox tests
+        run: |
+          tox -e py
+
+      - name: Tox MyPy
+        if: "!startsWith(matrix.python-version, 'pypy')"
+        run: |
+          tox -e mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.8", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["pypy3.8", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,30 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["pypy3.8", "3.6", "3.7", "3.8", "3.9"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+          cache: pip
+          cache-dependency-path: setup.py
 
       - name: Install dependencies
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-    - "3.6"
-    - "3.7"
-    - "3.8"
-    - "3.9"
-    - "pypy3"
-install: pip install tox
-script: tox -e mypy,py

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,6 @@ only support the latest version (**4.x**).
 
 Installation is as simple as ``pip install tinyrecord``.
 
-.. image:: https://travis-ci.org/eugene-eeo/tinyrecord.svg?branch=master
-    :target: https://travis-ci.org/eugene-eeo/tinyrecord
+.. image:: https://github.com/eugene-eeo/tinyrecord/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/eugene-eeo/tinyrecord/actions/workflows/test.yml
 .. _TinyDB: https://github.com/msiemens/tinydb

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
                    /___/
 
 
-**Supported Pythons:** 3.5+
+**Supported Pythons:** 3.6+
 
 Tinyrecord is a library which implements atomic
 transaction support for the `TinyDB`_ NoSQL database.
@@ -34,7 +34,7 @@ thread lock. Usage example:
         tr.insert_multiple(documents)
 
 Note that due to performance reasons you cannot view
-the data within a transaction unless you've comitted.
+the data within a transaction unless you've committed.
 You will have to call operations on the transaction
 object and not the database itself. Since tinyrecord
 works with dictionaries and the latest API, it will

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3 :: Only
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3 :: Only
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows

--- a/tinyrecord/transaction.py
+++ b/tinyrecord/transaction.py
@@ -42,7 +42,7 @@ def records(cls: Type[Operation]) -> Callable[..., None]:
     @wraps(cls)
     def proxy(self: "transaction", *args: Any, **kwargs: Any) -> None:
         # Too many arguments for "Operation"
-        self.record.append(cls(*args, **kwargs))  # type: ignore[call-arg]
+        self.record.append(cls(*args, **kwargs))
     return proxy
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,py3}, mypy
+envlist = py{36,37,38,39,310,311,py3}, mypy
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,py3}, mypy
+envlist = py{36,37,38,39,310,py3}, mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Includes PR #16.

* Add support for Python 3.10, was released in October 2021.

* Add support for Python 3.11, will be released in October 2022.

Sample build: https://github.com/hugovk/tinyrecord/actions/runs/3133209105